### PR TITLE
Updated disks for GCP HA in Default configuration pageAdded 'One 10 GiB Standard persistent disk for mediator boot data' to…

### DIFF
--- a/reference-default-configs.adoc
+++ b/reference-default-configs.adoc
@@ -134,7 +134,7 @@ If the virtual machine that you chose for Cloud Volumes ONTAP supports Ultra SSD
 
 === Azure (HA pair)
 
-*	Two 10 GiB Premium SSD disks for the boot volume (one per node)
+* Two 10 GiB Premium SSD disks for the boot volume (one per node)
 * Two 140 GiB Premium Storage page blobs for the root volume (one per node)
 * Two 1024 GiB Standard HDD disks for saving cores (one per node)
 * Two 512 GiB Premium SSD disks for NVRAM (one per node)
@@ -154,11 +154,12 @@ ifdef::gcp[]
 
 === Google Cloud (HA pair)
 
-* Two 10 GiB SSD persistent disks for boot data
-* Four 64 GiB SSD persistent disk for root data
+* Two 10 GiB SSD persistent disks for boot data 
+* Four 64 GiB SSD persistent disk for root data 
 * Two 500 GiB SSD persistent disk for NVRAM
-* Two 315 GiB Standard persistent disk for saving cores
+* Two 315 GiB Standard persistent disk for saving cores 
 * One 10 GiB Standard persistent disk for mediator data
+* One 10 GiB Standard persistent disk for mediator boot data
 * Snapshots for boot and root data
 * Boot and root disks are encrypted by default.
 endif::gcp[]


### PR DESCRIPTION
Added 'One 10 GiB Standard persistent disk for mediator boot data' to Google Cloud HA pairs after receiving feedback.

#113 